### PR TITLE
Add Initial Dockerfile for the frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Base image
+FROM node:latest
+
+COPY package*.json ./
+
+# 캐시 정리 후 설치
+RUN npm cache clean --force && npm install
+
+# Copy the rest of the application
+COPY . .
+
+# Expose port
+EXPOSE 3000
+
+# Run application
+CMD ["npm", "start"]~


### PR DESCRIPTION
## 관련된 이슈 번호


## 주요 구현 사항
- Dockerfile을 추가하여 `frontend` 서비스의 Docker 컨테이너화를 구현
- `npm Tracker "idealTree" already exists` 오류를 해결하기 위해 `npm cache clean --force` 명령어를 Dockerfile에 추가

## 리뷰어 참고 사항

### 테스트 방법
1. Dockerfile을 사용하여 `frontend` 서비스 컨테이너를 빌드

   ```bash
   docker build -t frontend .
2. 컨테이너 실행 후 npm install 및 npm start 명령이 정상적으로 실행되는지 확인